### PR TITLE
feat: added --verbosity flag

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,6 +29,15 @@ module.exports = {
 			rules: {
 				// These off-by-default rules work well for this repo and we like them on.
 				"deprecation/deprecation": "error",
+
+				// Todo: this can be removed when typescript-eslint@6 is released.
+				"@typescript-eslint/restrict-template-expressions": [
+					"error",
+					{
+						allowBoolean: true,
+						allowNullish: true,
+					},
+				],
 			},
 		},
 		{

--- a/README.md
+++ b/README.md
@@ -28,14 +28,57 @@
 
 ## Usage
 
+This CLI script determines whether a semantic release should occur for a package based on Git history.
+Specifically, it returns truthy only if a commit whose type _isn't_ `chore` or `docs` has come since the most recent release commit.
+
 ```shell
-npm i should-semantic-release
+if npx should-semantic-release ; then npx release-it ; fi
 ```
 
-```ts
-import { greet } from "should-semantic-release";
+This can be useful, for example, to [prevent a `release-it` release](https://github.com/release-it/release-it/issues/969):
 
-greet("Hello, world!");
+```json
+{
+	"hooks": {
+		"before:bump": "if ! npx should-semantic-release ; then exit 1 ; fi"
+	}
+}
+```
+
+`should-semantic-release` accepts the following CLI flag:
+
+- `-v`/`--verbose` _(default: `false`)_: Whether to log debug information to the console
+
+```plaintext
+$ npx should-semantic-release
+
+Checking up to 123 commits for release readiness...
+Checking commit: chore: an example chore (#101)
+Found type chore.
+Checking commit: chore: another example chore (#100)
+Found type chore.
+Checking commit: chore: release v1.27.31
+This is a release commit. Returning false.
+```
+
+### Node API
+
+Alternately, you can call this import asynchronous `shouldSemanticRelease` function into Node scripts:
+
+```ts
+import { shouldSemanticRelease } from "should-semantic-release";
+
+if (await shouldSemanticRelease()) {
+	console.log("Let's release! 🚀");
+}
+```
+
+`shouldSemanticRelease` accepts an optional options object with the following parameter:
+
+- `verbose` _(default: `false`)_
+
+```js
+await shouldSemanticRelease({ verbose: true });
 ```
 
 ## Development

--- a/bin/should-semantic-release.mjs
+++ b/bin/should-semantic-release.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { shouldSemanticRelease } from "../lib/index.js";
+import { shouldSemanticReleaseCLI } from "../lib/cli.js";
 
 try {
-	if (!(await shouldSemanticRelease())) {
+	if (!(await shouldSemanticReleaseCLI(process.argv.slice(2)))) {
 		process.exitCode = 1;
 	}
 } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,18 @@
+import { parseArgs } from "node:util";
+
+import { shouldSemanticRelease } from "./shouldSemanticRelease.js";
+
+export async function shouldSemanticReleaseCLI(args: string[]) {
+	const { values } = parseArgs({
+		args,
+		options: {
+			verbose: { short: "v", type: "boolean" },
+		},
+		strict: false,
+		tokens: true,
+	});
+
+	return await shouldSemanticRelease({
+		verbose: !!values.verbose,
+	});
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./cli.js";
 export * from "./shouldSemanticRelease.js";

--- a/src/shouldSemanticRelease.ts
+++ b/src/shouldSemanticRelease.ts
@@ -1,28 +1,47 @@
 import conventionalCommitsParser from "conventional-commits-parser";
 
 import { isReleaseCommit } from "./isReleaseCommit.js";
+import { ShouldSemanticReleaseOptions } from "./types.js";
 import { execOrThrow } from "./utils.js";
 
 const ignoredTypes = new Set(["chore", "docs"]);
 
-export async function shouldSemanticRelease() {
+export async function shouldSemanticRelease({
+	verbose,
+}: ShouldSemanticReleaseOptions) {
 	const rawHistory = await execOrThrow(`git log --pretty=format:"%s"`);
 	const history = rawHistory.split("\n");
 
+	const log = verbose
+		? console.log.bind(console)
+		: // eslint-disable-next-line @typescript-eslint/no-empty-function
+		  () => {};
+
+	log(`Checking up to ${history.length} commits for release readiness...`);
+
 	for (let i = 0; i < history.length; i += 1) {
 		const message = history[i];
+		log(`Checking commit: ${message}`);
 		// If the commit is a release, we should only release if other commits have been found
 		if (isReleaseCommit(message)) {
-			return !!i;
+			const result = !!i;
+			log(`Found a release commit. Returning ${result}.`);
+			return result;
 		}
 
 		// Otherwise, we should release if a non-ignored commit type is found
 		const { type } = conventionalCommitsParser.sync(message);
 		if (type && !ignoredTypes.has(type)) {
+			log(`Found a meaningful commit. Returning true.`);
 			return true;
 		}
+
+		log(`Found type ${type}. Continuing.`);
 	}
 
 	// If we've seen every commit in the history and none match, don't release
+	log(
+		"No commits found that indicate a semantic release is necessary. Returning false."
+	);
 	return false;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface ShouldSemanticReleaseOptions {
+	verbose?: boolean;
+}


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #6
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds `--verbose` and documents it in the README.md. Adds a `cli.ts` file for CLI parsing before the main `shouldSemanticRelease` logic.