### PR TITLE
fix: always return false if a release commit is found

### DIFF
--- a/src/shouldSemanticRelease.ts
+++ b/src/shouldSemanticRelease.ts
@@ -19,14 +19,12 @@ export async function shouldSemanticRelease({
 
 	log(`Checking up to ${history.length} commits for release readiness...`);
 
-	for (let i = 0; i < history.length; i += 1) {
-		const message = history[i];
+	for (const message of history) {
 		log(`Checking commit: ${message}`);
 		// If the commit is a release, we should only release if other commits have been found
 		if (isReleaseCommit(message)) {
-			const result = !!i;
-			log(`Found a release commit. Returning ${result}.`);
-			return result;
+			log(`Found a release commit. Returning false.`);
+			return false;
 		}
 
 		// Otherwise, we should release if a non-ignored commit type is found


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #5
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Simplifies a bit of the logic. Yay!