### PR TITLE
fix: consider version-number-only commit as a release

### DIFF
--- a/src/isReleaseCommit.test.ts
+++ b/src/isReleaseCommit.test.ts
@@ -12,13 +12,21 @@ describe("isReleaseCommit", () => {
 		[false, "docs: bump"],
 		[false, "feat"],
 		[false, "feat: bump"],
+		[true, "0.0.0"],
+		[true, "v0.0.0"],
+		[true, "1.2.3"],
+		[true, "v1.2.3"],
+		[true, "1.23.456"],
+		[true, "v1.23.456"],
+		[true, "12.345.6789"],
+		[true, "v12.345.6789"],
 		[true, "chore: release"],
 		[true, "chore: release 1.2.3"],
 		[true, "chore: release v1.2.3"],
 		[true, "chore(deps): release"],
 		[true, "chore(deps): release 1.2.3"],
 		[true, "chore(deps): release v1.2.3"],
-	])("returns %b for %s", (expected, input) => {
+	])("returns %j for %s", (expected, input) => {
 		expect(isReleaseCommit(input)).toBe(expected);
 	});
 });

--- a/src/isReleaseCommit.ts
+++ b/src/isReleaseCommit.ts
@@ -1,4 +1,4 @@
-const tester = /^(?:chore(?:\(.*\))?:?)?\s*release/;
+const tester = /^(?:chore(?:\(.*\))?:?)?\s*release|v?\d+\.\d+\.\d+/;
 
 export function isReleaseCommit(message: string) {
 	return tester.test(message);

--- a/src/shouldSemanticRelease.ts
+++ b/src/shouldSemanticRelease.ts
@@ -21,7 +21,7 @@ export async function shouldSemanticRelease({
 
 	for (const message of history) {
 		log(`Checking commit: ${message}`);
-		// If the commit is a release, we should only release if other commits have been found
+		// If we've hit a release commit, we know we don't need to release
 		if (isReleaseCommit(message)) {
 			log(`Found a release commit. Returning false.`);
 			return false;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #23
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Accounts for an optional `v` before three digits separated by `.`s.