### PR TITLE
feat: support BREAKING CHANGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ This is a release commit. Returning false.
 Based on a commit's conventional commit message type:
 
 1. If the type is `feat` `fix`, or `perf`, it's considered "meaningful"
-2. If the type is `docs`, `refactor`, `style`, or `test`, it's ignored
-3. If the message looks like `v1.2.3`, `chore: release 1.2.3`, or similar, it's considered a "release"
+1. If the commit is marked as being a breaking change, either via a note or via an `!` appended to the type, it's considered "meaningful"
+1. If the type is `docs`, `refactor`, `style`, or `test`, it's ignored
+1. If the message looks like `v1.2.3`, `chore: release 1.2.3`, or similar, it's considered a "release"
 
 See [`getCommitMeaning`](./src/getCommitMeaning.ts) for the exact logic used.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This is a release commit. Returning false.
 Based on a commit's conventional commit message type:
 
 1. If the type is `feat` `fix`, or `perf`, it's considered "meaningful"
-1. If the commit is marked as being a breaking change, either via a note or via an `!` appended to the type, it's considered "meaningful"
+1. If the commit is marked as being a breaking change, either via a `BREAKING CHANGE:` at the start of any commit message lines or via an `!` appended to the type, it's considered "meaningful"
 1. If the type is `docs`, `refactor`, `style`, or `test`, it's ignored
 1. If the message looks like `v1.2.3`, `chore: release 1.2.3`, or similar, it's considered a "release"
 

--- a/src/getCommitMeaning.test.ts
+++ b/src/getCommitMeaning.test.ts
@@ -61,6 +61,20 @@ describe("getCommitMeaning", () => {
 			"chore: deps\n\nMultiple: footer notes\nMultiple: footer notes",
 			{ type: "chore" },
 		],
+		// This test may should be { type: "chore" },
+		// but conventionalCommitsParser looks like can't parse this case correctly
+		[
+			"chore: deps\n\nBREAKING CHANGE line starts with BREAKING CHANGE (no :)",
+			"meaningful",
+		],
+		[
+			"chore: deps\n\nline contains BREAKING CHANGE:  inside it",
+			{ type: "chore" },
+		],
+		[
+			"BREAKING CHANGE (major): line starts with something like BREAKING CHANGE",
+			{ type: undefined },
+		],
 	])("returns %j for %s", (input, expected) => {
 		expect(getCommitMeaning(input)).toEqual(expected);
 	});

--- a/src/getCommitMeaning.test.ts
+++ b/src/getCommitMeaning.test.ts
@@ -40,6 +40,27 @@ describe("getCommitMeaning", () => {
 		["chore(deps): release", "release"],
 		["chore(deps): release 1.2.3", "release"],
 		["chore(deps): release v1.2.3", "release"],
+		["chore!: message", "meaningful"],
+		["docs!: message", "meaningful"],
+		["chore!: release", "meaningful"],
+		["feat!: a feature with a breaking change", "meaningful"],
+		["chore: bump\n\nBREAKING CHANGE: breaks things", "meaningful"],
+		["chore: bump\n\nBREAKING-CHANGE: breaks things", "meaningful"],
+		["docs: bump\n\nBREAKING CHANGE: breaks things", "meaningful"],
+		["docs: bump\n\nBREAKING-CHANGE: breaks things", "meaningful"],
+		[
+			"chore: deps\n\nBREAKING-CHANGE: breaks things\nMultiple: footer notes",
+			"meaningful",
+		],
+		["chore: deps\n\n! in the commit body", { type: "chore" }],
+		[
+			"chore: deps\n\nFooter-note: other than BREAKING CHANGE",
+			{ type: "chore" },
+		],
+		[
+			"chore: deps\n\nMultiple: footer notes\nMultiple: footer notes",
+			{ type: "chore" },
+		],
 	])("returns %j for %s", (input, expected) => {
 		expect(getCommitMeaning(input)).toEqual(expected);
 	});

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -7,7 +7,16 @@ const alwaysIgnoredTypes = new Set(["docs", "refactor", "style", "test"]);
 const releaseCommitTester =
 	/^(?:chore(?:\(.*\))?:?)?\s*release|v?\d+\.\d+\.\d+/;
 
+const breakChangingCommitTester = [
+	/^\w+(?:\(.+\))?!:\s*/,
+	/^\w+(?:\(.+\))?!?:\s[^\n]*\n[^\n]*\n.*BREAKING[ |-]CHANGE: /s,
+];
+
 export function getCommitMeaning(message: string) {
+	if (breakChangingCommitTester.some((tester) => tester.test(message))) {
+		return "meaningful";
+	}
+
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
 	const { type } = conventionalCommitsParser.sync(message);
 	if (type) {

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -7,18 +7,19 @@ const alwaysIgnoredTypes = new Set(["docs", "refactor", "style", "test"]);
 const releaseCommitTester =
 	/^(?:chore(?:\(.*\))?:?)?\s*release|v?\d+\.\d+\.\d+/;
 
-const breakChangingCommitTester = [
-	/^\w+(?:\(.+\))?!:\s*/,
-	/^\w+(?:\(.+\))?!?:\s[^\n]*\n[^\n]*\n.*BREAKING[ |-]CHANGE: /s,
-];
+const breakChangingCommitTester = /^\w+(?:\(.+\))?!/;
 
 export function getCommitMeaning(message: string) {
-	if (breakChangingCommitTester.some((tester) => tester.test(message))) {
+	if (breakChangingCommitTester.test(message)) {
 		return "meaningful";
 	}
 
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
-	const { type } = conventionalCommitsParser.sync(message);
+	const { notes, type } = conventionalCommitsParser.sync(message);
+	if (notes.some((note) => note.title.match(/BREAKING[ -]CHANGE/))) {
+		return "meaningful";
+	}
+
 	if (type) {
 		if (alwaysMeaningfulTypes.has(type)) {
 			return "meaningful";

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -14,7 +14,7 @@ export function getCommitMeaning(message: string) {
 		breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
 		headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
 	});
-	if (notes.some((note) => note.title.match(/BREAKING[ -]CHANGE/))) {
+	if (notes.some((note) => note.title.match(/^BREAKING[ -]CHANGE$/))) {
 		return "meaningful";
 	}
 

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -12,7 +12,6 @@ export function getCommitMeaning(message: string) {
 	const { notes, type } = conventionalCommitsParser.sync(message, {
 		// @ts-expect-error - options from https://github.com/conventional-changelog/conventional-changelog/issues/648#issuecomment-704867077
 		breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
-		headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
 	});
 	if (notes.some((note) => note.title.match(/^BREAKING[ -]CHANGE$/))) {
 		return "meaningful";

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -9,10 +9,10 @@ const releaseCommitTester =
 
 export function getCommitMeaning(message: string) {
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
+	// options from https://github.com/conventional-changelog/conventional-changelog/issues/648#issuecomment-704867077
 	const { notes, type } = conventionalCommitsParser.sync(message, {
-		// @ts-expect-error - options from https://github.com/conventional-changelog/conventional-changelog/issues/648#issuecomment-704867077
 		breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
-	});
+	} as object);
 	if (notes.some((note) => note.title.match(/^BREAKING[ -]CHANGE$/))) {
 		return "meaningful";
 	}

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -7,15 +7,13 @@ const alwaysIgnoredTypes = new Set(["docs", "refactor", "style", "test"]);
 const releaseCommitTester =
 	/^(?:chore(?:\(.*\))?:?)?\s*release|v?\d+\.\d+\.\d+/;
 
-const breakChangingCommitTester = /^\w+(?:\(.+\))?!/;
-
 export function getCommitMeaning(message: string) {
-	if (breakChangingCommitTester.test(message)) {
-		return "meaningful";
-	}
-
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
-	const { notes, type } = conventionalCommitsParser.sync(message);
+	const { notes, type } = conventionalCommitsParser.sync(message, {
+		// @ts-expect-error - options from https://github.com/conventional-changelog/conventional-changelog/issues/648#issuecomment-704867077
+		breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+		headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/,
+	});
 	if (notes.some((note) => note.title.match(/BREAKING[ -]CHANGE/))) {
 		return "meaningful";
 	}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to should-semantic-release! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #139 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

continue #140 
related https://github.com/conventional-changelog/conventional-changelog/issues/648