### PR TITLE
fix: should recognise breaking changes

### DIFF
--- a/src/getCommitMeaning.test.ts
+++ b/src/getCommitMeaning.test.ts
@@ -79,6 +79,14 @@ describe("getCommitMeaning", () => {
 			"BREAKING CHANGE (major): line starts with something like BREAKING CHANGE and has modifier",
 			"meaningful",
 		],
+		[
+			"BREAKING-CHANGE: line starts with something like BREAKING-CHANGE",
+			"meaningful",
+		],
+		[
+			"BREAKING-CHANGE (major): line starts with something like BREAKING-CHANGE and has modifier",
+			"meaningful",
+		],
 	])("returns %j for %s", (input, expected) => {
 		expect(getCommitMeaning(input)).toEqual(expected);
 	});

--- a/src/getCommitMeaning.test.ts
+++ b/src/getCommitMeaning.test.ts
@@ -72,8 +72,12 @@ describe("getCommitMeaning", () => {
 			{ type: "chore" },
 		],
 		[
-			"BREAKING CHANGE (major): line starts with something like BREAKING CHANGE",
-			{ type: undefined },
+			"BREAKING CHANGE: line starts with something like BREAKING CHANGE",
+			"meaningful",
+		],
+		[
+			"BREAKING CHANGE (major): line starts with something like BREAKING CHANGE and has modifier",
+			"meaningful",
 		],
 	])("returns %j for %s", (input, expected) => {
 		expect(getCommitMeaning(input)).toEqual(expected);

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -9,10 +9,13 @@ const releaseCommitTester =
 
 export function getCommitMeaning(message: string) {
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
-	const { notes, type } = conventionalCommitsParser.sync(message, {
+	const { header, notes, type } = conventionalCommitsParser.sync(message, {
 		breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
 	});
-	if (notes.some((note) => note.title.match(/^BREAKING[ -]CHANGE$/))) {
+	if (
+		notes.some((note) => note.title.match(/^BREAKING[ -]CHANGE$/)) ||
+		header?.match(/^BREAKING[ -]CHANGE(?: \([^)]+\))?:/)
+	) {
 		return "meaningful";
 	}
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to should-semantic-release! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #507
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This PR amends behaviour to recognise BREAKING CHANGE as meaningful