### PR TITLE
fix: treat common chore(deps): ... messages as chores

### DIFF
--- a/src/getCommitMeaning.test.ts
+++ b/src/getCommitMeaning.test.ts
@@ -34,6 +34,9 @@ describe("getCommitMeaning", () => {
 		["v1.23.456", "release"],
 		["12.345.6789", "release"],
 		["v12.345.6789", "release"],
+		["chore(deps): bump dependency abc", { type: "chore" }],
+		["chore(deps): update dependency abc", { type: "chore" }],
+		["chore(deps): update dependency abc to v1.2.3", { type: "chore" }],
 		["chore: release", "release"],
 		["chore: release 1.2.3", "release"],
 		["chore: release v1.2.3", "release"],
@@ -87,7 +90,7 @@ describe("getCommitMeaning", () => {
 			"BREAKING-CHANGE (major): line starts with something like BREAKING-CHANGE and has modifier",
 			"meaningful",
 		],
-	])("returns %j for %s", (input, expected) => {
+	])("for %j returns %s", (input, expected) => {
 		expect(getCommitMeaning(input)).toEqual(expected);
 	});
 });

--- a/src/getCommitMeaning.ts
+++ b/src/getCommitMeaning.ts
@@ -4,8 +4,10 @@ const alwaysMeaningfulTypes = new Set(["feat", "fix", "perf"]);
 
 const alwaysIgnoredTypes = new Set(["docs", "refactor", "style", "test"]);
 
-const releaseCommitTester =
-	/^(?:chore(?:\(.*\))?:?)?\s*release|v?\d+\.\d+\.\d+/;
+const releaseCommitTesters = [
+	/^(?:chore(?:\(.*\))?:?)?\s*release\b/i,
+	/^v?\d+\.\d+\.\d+?\.?/,
+];
 
 export function getCommitMeaning(message: string) {
 	// Some types are always meaningful or ignored, regardless of potentially release-like messages
@@ -30,7 +32,7 @@ export function getCommitMeaning(message: string) {
 	}
 
 	// If we've hit a release commit, we know we don't need to release
-	if (releaseCommitTester.test(message)) {
+	if (releaseCommitTesters.some((regex) => regex.test(message))) {
 		return "release";
 	}
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #569
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/should-semantic-release/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/should-semantic-release/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes the `releaseCommitTesters` logic to have multiple, less lenient regular expressions.

💂